### PR TITLE
chore: support docker-based deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,25 +1,29 @@
-name: Deploy
+name: Build Docker Image
 
 on:
   push:
     branches: [ main ]
+  workflow_dispatch:
 
 jobs:
   deploy:
-    name: Release Production Build
+    name: Create build artifact
     runs-on: ubuntu-latest
     steps:
 
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
-    - name: Deploy to Heroku
-      uses: akhileshns/heroku-deploy@v3.12.12
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
       with:
-        heroku_api_key: ${{ secrets.HEROKU_API_KEY }}
-        heroku_app_name: "sparkbox-reaction-bot"
-        heroku_email: ${{ secrets.USER_EMAIL }}
-        usedocker: true
-        docker_heroku_process_type: worker
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build image
+      run: |
+        docker build . --tag ghcr.io/sparkbox/reaction-bot:latest
+        docker push ghcr.io/sparkbox/reaction-bot:latest

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ A small but mighty implementation of the [Reaction Bot library][reaction_bot_rep
 
 ## Running locally
 
-To run this project locally, copy the contents of `.env-sample` to `.env` and replace the token with the correct tokens from Slack.
+To run this project locally, copy the contents of `.env-sample` to `.env` and replace the token with the correct tokens from Slack. You can either run the project with a local Go installation, or you can use Docker.
+
+### Go
 
 To install dependencies, run:
 
@@ -24,9 +26,32 @@ To compile the binary, run:
 go build main.go
 ```
 
-### Customizing
+### Docker
+
+To build the container after initial setup or making changes, run:
+
+```cli
+docker compose build
+```
+
+To run the binary from the container, run:
+
+```cli
+docker compose up
+```
+
+## Customizing
 
 Looking to shake things up? You can customize the emoji and the channels they should post to in `reaction-bot.go` by modifying `registeredReactions`. For configuration options on registering emoji, see the [docs][reaction_bot_register_emoji].
 
 [reaction_bot_repo]: http://github.com/jordanleven/reaction-bot
 [reaction_bot_register_emoji]: https://github.com/jordanleven/reaction-bot#registering-emoji
+
+## Deploying
+
+When changes are pushed to `main`, an image is built and published to the GitHub Container Registry. From the server, you can pull the image and restart the bot with following commands:
+
+```cli
+docker pull ghcr.io/sparkbox/reaction-bot
+docker compose up -d
+```

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,8 @@
+version: '3.8'
+services:
+  reaction_bot:
+    image: ghcr.io/sparkbox/reaction-bot:latest
+    container_name: reaction_bot
+    restart: always
+    env_file:
+      - .env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.8'
+services:
+  reaction_bot:
+    build:
+      context: .
+    container_name: reaction_bot
+    restart: always
+    env_file:
+      - .env

--- a/go.mod
+++ b/go.mod
@@ -1,13 +1,19 @@
 module github.com/sparkbox/reaction-bot
 
-go 1.12
+go 1.22
+
+require github.com/jordanleven/reaction-bot v1.1.0
 
 require (
+	github.com/fatih/color v1.10.0 // indirect
 	github.com/go-test/deep v1.0.7 // indirect
-	github.com/jordanleven/reaction-bot v1.1.0
-	github.com/kr/text v0.2.0 // indirect
+	github.com/gorilla/websocket v1.4.2 // indirect
+	github.com/joho/godotenv v1.3.0 // indirect
+	github.com/mattn/go-colorable v0.1.8 // indirect
+	github.com/mattn/go-isatty v0.0.12 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/slack-go/slack v0.8.2 // indirect
 	github.com/stretchr/testify v1.7.0 // indirect
 	golang.org/x/sys v0.0.0-20210309074719-68d13333faf2 // indirect
-	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,3 @@
-github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -13,12 +12,6 @@ github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/jordanleven/reaction-bot v1.1.0 h1:knGsqXF1w3qy7ALzKkUp+zBaStJuFw2ZOQIOZnlu94Y=
 github.com/jordanleven/reaction-bot v1.1.0/go.mod h1:CUjn8OZ22kUZktWTGfpTePY1VZalpEP079pjWyv38kg=
-github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
-github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
-github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
-github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
-github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/mattn/go-colorable v0.1.8 h1:c1ghPdyEDarC70ftn0y+A/Ee++9zz8ljHG1b13eJ0s8=
 github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
@@ -39,8 +32,6 @@ golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210309074719-68d13333faf2 h1:46ULzRKLh1CwgRq2dC5SlBzEqqNCi8rreOZnNrbqcIY=
 golang.org/x/sys v0.0.0-20210309074719-68d13333faf2/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
-gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
## Description

This work updates the deployment workflow to publish a docker image to the GitHub Container Registry instead of deploying to Heroku. It also sets up `docker-compose` configs and updates the Go version/dependencies.

## To Validate

1. Pull down this branch
2. If you haven't already, copy `.env-sample` to `.env` and fill in the token values
3. Run `docker compose up`, confirming that you see output confirming that you are connected to Slack and that Reaction Bot has started up
4. Modify `main.go` to add another reaction using an emoji of your choice with a unique `Name` and `reaction-bot-testing` for the `Channel`
5. Run `docker compose build`, then `docker compose up` to rebuild/restart the bot locally
6. Use the emoji you specified in a Slack channel that has Reaction Bot, confirming that the message is posted to `#reaction-bot-testing` and that the `Name` you specified is logged to the console
7. Check the [workflow run](https://github.com/sparkbox/reaction-bot/actions/runs/7877353652/job/21493343093?pr=3) for publishing the docker image, and make sure that the [package is deployed](https://github.com/sparkbox/reaction-bot/pkgs/container/reaction-bot)
8. Run `docker compose -f docker-compose.prod.yml`, confirming that it pulls the image and runs it (this will require a personal access token to access the registry)