### PR TITLE
feat: rename gems channel

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,7 +7,7 @@ import (
 var registeredReactions = reactionbot.RegisteredReactions{
 	"gem": {
 		Name:    "Gem",
-		Channel: "-gems",
+		Channel: "gems",
 	},
 	"til": {
 		Name:    "Today I learned",


### PR DESCRIPTION
## Description

This changes the name of the gems channel from "-gems" to "gems". It would be nice to have a dynamic way to change the registered reactions, but that level of effort doesn't seem justified here.

## To Validate

1. Pull down this branch
2. Run `docker compose build`
3. Run `docker compose up`
4. Add a "gem" reaction to a message in a channel using Reaction Bot while there's a "#-gems" channel (it shouldn't work)
5. Try again after the channel is renamed to "#gems" (it should work)